### PR TITLE
Fix typo in register.md

### DIFF
--- a/docs/shared/ecs/Component/register.md
+++ b/docs/shared/ecs/Component/register.md
@@ -2,7 +2,7 @@
 
 ## arguments
 
-no arguements
+no arguments
 
 ## description
 


### PR DESCRIPTION
## Summary
- fix a typo in docs/shared/ecs/Component/register.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886656fb65c83249cc45f94ff51a0a2